### PR TITLE
Moved semicolon outside of backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ expression.
 ```js
 function outer(greeting, msg="It's a fine day to learn") {
   return function(name, lang="Python") {
-    return `${greeting}, ${name}! ${msg} ${lang};`
+    return `${greeting}, ${name}! ${msg} ${lang}`;
   }
 }
 


### PR DESCRIPTION
If a student tried to copy and paste the code block, they would have a syntax error so I just moved the semicolon outside the backticks.